### PR TITLE
Add support for GCC 4.8.5 on CentOS 7.7

### DIFF
--- a/include/io/data_source.hpp
+++ b/include/io/data_source.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <iostream>
 #include <algorithm>
 #include <string>

--- a/src/iact_data/zfits_actl_r1_data_source.cpp
+++ b/src/iact_data/zfits_actl_r1_data_source.cpp
@@ -756,7 +756,7 @@ std::tuple<calin::io::zmq_inproc::ZMQPusher*, calin::io::zmq_inproc::ZMQPuller*>
 ZMQACTL_R1_CameraEventDataSource::InProcPayloadDistributer::connect()
 {
   num_connections_.fetch_add(1);
-  return { new_upstream_pusher(), new_downstream_puller() };
+  return std::make_tuple(new_upstream_pusher(), new_downstream_puller());
 }
 
 void ZMQACTL_R1_CameraEventDataSource::InProcPayloadDistributer::main_loop()

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -39,6 +39,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <pwd.h>
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <fstream>


### PR DESCRIPTION
Happy New Year Steve!
Thanks for your work in https://github.com/llr-cta/calin/pull/140 to support GCC 4.8.
I tried it out and here are the changes I still needed for a successful build.